### PR TITLE
Add helper methods to get slot properties

### DIFF
--- a/cek/core/models.py
+++ b/cek/core/models.py
@@ -274,6 +274,42 @@ class IntentRequest(Request):
         if slots is not None and slot_name in slots:
             return slots[slot_name]['value']
 
+    def slot_value_type(self, slot_name):
+        """Returns slot valueType or None if missing.
+
+        :param str slot_name: slot name
+        :returns: slot valueType if exists, None otherwise.
+
+        Usage:
+            >>> @clova.handle.intent("TurnOn")
+            >>> def turn_on_handler(request):
+            >>>     request.slot_value_type('when')
+            'TIME.INTERVAL'
+        """
+        slots = self._request['intent']['slots']
+        if slots is not None and slot_name in slots:
+            slot = slots[slot_name]
+            if 'valueType' in slot:
+                return slot['valueType']
+
+    def slot_unit(self, slot_name):
+        """Returns slot unit or None if missing.
+
+        :param str slot_name: slot name
+        :returns: slot unit if exists, None otherwise.
+
+        Usage:
+            >>> @clova.handle.intent("TurnOn")
+            >>> def turn_on_handler(request):
+            >>>     request.slot_unit('degree')
+            '°C'
+        """
+        slots = self._request['intent']['slots']
+        if slots is not None and slot_name in slots:
+            slot = slots[slot_name]
+            if 'unit' in slot:
+                return slot['unit']
+
 
 class EventRequest(Request):
     """ Request received when an event on the user's device occurred.

--- a/test/data/requests.py
+++ b/test/data/requests.py
@@ -230,6 +230,16 @@ INTENT_REQUEST_BODY = b"""
                 "Light": {
                     "name": "Light",
                     "value": "\xe9\x9b\xbb\xe6\xb0\x97"
+                },
+                "when": {
+                    "name": "when",
+                    "value": "19:00:00/19:30:00",
+                    "valueType": "TIME.INTERVAL"
+                },
+                "degree": {
+                    "name": "degree",
+                    "value": "27",
+                    "unit": "\xc2\xb0C"
                 }
             }
         }

--- a/test/test_core_intent_requests.py
+++ b/test/test_core_intent_requests.py
@@ -57,12 +57,32 @@ class Test_IntentRequest(unittest.TestCase):
 
         self.assertEqual(value, u"電気")
 
+    def test_request_returns_slot_value_type(self):
+        value = self.request.slot_value_type("when")
+
+        self.assertEqual(value, "TIME.INTERVAL")
+
+    def test_request_returns_no_slot_value_type(self):
+        value = self.request.slot_value_type("Light")
+
+        self.assertIsNone(value)
+
+    def test_request_returns_slot_unit(self):
+        value = self.request.slot_unit("degree")
+
+        self.assertEqual(value, u"°C")
+
+    def test_request_returns_no_slot_unit(self):
+        value = self.request.slot_unit("when")
+
+        self.assertIsNone(value)
+
     def test_slots(self):
         slots = self.request.slots
         if "Light" in slots:
             light_value = slots["Light"]
 
-        expected_slots = {'AirCon': 'Air Conditioner', 'Light': u'電気'}
+        expected_slots = {'AirCon': 'Air Conditioner', 'Light': u'電気', 'when': '19:00:00/19:30:00', 'degree': '27'}
         expected_light_value = u'電気'
         self.assertEqual(slots, expected_slots)
         self.assertEqual(light_value, expected_light_value)


### PR DESCRIPTION
This PR adds following helper methods to get slot properties.
- `IntentRequest.slot_value_type(slot_name)`
- `IntentRequest.slot_unit(slot_name)`
